### PR TITLE
fix: layout en contenedor de eventos

### DIFF
--- a/src/app/landing/home/components/events-resume/event-box/event-box.component.html
+++ b/src/app/landing/home/components/events-resume/event-box/event-box.component.html
@@ -1,7 +1,5 @@
 <div
   class="event-box"
-  [ngStyle.gt-xs]="{'width': '42vw'}"
-  [ngStyle.gt-md]="{'width': '28vw'}"
   [ngClass]="{'invert-color': position % 2 === 0}" >
   <h4>{{eventInfo.name | ellipsis : 35}}</h4>
   <p>{{eventInfo.description | ellipsis : 60 }}</p>

--- a/src/app/landing/home/components/events-resume/event-box/event-box.component.scss
+++ b/src/app/landing/home/components/events-resume/event-box/event-box.component.scss
@@ -2,7 +2,6 @@
 
 .event-box {
   padding: 16px 16px 50px;
-  width: 100%;
   // width: 28vw; // fix responsive
   min-height: 15em;
   h4 {

--- a/src/app/landing/home/components/events-resume/events-resume.component.html
+++ b/src/app/landing/home/components/events-resume/events-resume.component.html
@@ -10,6 +10,7 @@
 
     <app-event-box
       class="box"
+      fxFlex
       *ngFor="let e of events | async;let i = index"
       [position]="i"
       [eventInfo]="e"

--- a/src/app/landing/home/components/events-resume/events-resume.component.scss
+++ b/src/app/landing/home/components/events-resume/events-resume.component.scss
@@ -1,6 +1,5 @@
 .events-resume {
   .boxes-container{
-    margin-left: -16px;
     margin-top: 4em;
   }
 }


### PR DESCRIPTION
En algunos casos no se veían los tres eventos sino que se veía el tercero partido a la mitad.